### PR TITLE
Proposal to add "Community Directory"

### DIFF
--- a/proposals/community-directory.md
+++ b/proposals/community-directory.md
@@ -1,0 +1,25 @@
+# Florida Hackers: Community Directory
+
+## Overview
+
+This initiative will bring forth a community directory that allows hackers, hackathon organizers, and other community members to identify tech-focused organizations within the state of Florida. This will enable interested parties to connect with others passionate about technology, furthering the Florida Hackers purpoe statement:
+> Florida Hackers is a network of university students that exists to connect passionate technology oriented creators across the Sunshine State.
+
+## Community needs
+
+This initiative will seek to remove any barriers to communicating with other universities, and enabling organizations to form membership bonds with one another to better support events with a mutual stake (such as hackathons and conferences.) 
+
+For example, a community with an upcoming hackathon event that is looking to engage the Florida Hackers community could reach out to the representatives of each organization of interest. Alternatively, a community holding a regional event (such as a Local Hack Day) could identify which organizations are within an hours driving distance to personally extend an invitation.
+
+## Resources
+
+This solution will require code implemented on the Florida Hackers website, allowing the implementation of an interactive map and list of all relevant organizations in the state of Florida. This access will be obtained through a pull request to the [Florida Hackers' website GitHub repository](https://github.com/floridahackers/fh-platform).
+
+## Timeline
+
+A rough timeline for this project is as follows:
+- *Prior to October 30th, 2017*: Identify what information is important to this directory of organizations
+- *Week of October 30th, 2017*: Add a map and list for organizations to populate from on the Florida Hackers website
+- *Week of November 6th, 2017*: Enable population from endpoint, such that a JSON object of the latest organizations will show on a map and list for ease of contribution
+- *Week of November 13th, 2017*: Establish a clear guideline for making a contribution to identify an organization's website, social media platform, and the relevant contact information
+


### PR DESCRIPTION
This is a proposal to create an interactive directory of the Florida Hackers community, identifies hacker clubs, interest groups, and other related entities at colleges and universities across the state. 

This interactive directory *could* feature the following:
- The contact information of respective group leaders
- The meeting dates and times for the groups and organizations
- The location of these organizations
- An interactive map of organizations across the state

This proposal would greater enable organization across the state to continue forming bonds between other member organizations of the Florida Hackers community, building upon the Florida Hackers purpose, "to connect passionate technology oriented creators across the Sunshine State."

What is everyone's thought on this? I am comfortable leading development of this extension to the Florida Hackers site. 